### PR TITLE
fix to docker build

### DIFF
--- a/eshop-mvc-modernized-app/README.md
+++ b/eshop-mvc-modernized-app/README.md
@@ -95,8 +95,9 @@ cd windows-containers-demos # Current working directory is D: \windows-container
 ## Building Docker Image
 
 ```powershell
+#Navigating to the folder below is optional. You might have cloned the repo to a different folder structure.
 cd D:\windows-containers-demos\eshop-mvc-modernized-app
-docker build -t eshopapp:v2.1  -f .\eshop.Dockerfile .
+docker build -t eshopapp:v2.1  -f .\application\eshop.Dockerfile .
 ```
 
 ## Create Azure Services

--- a/eshop-mvc-modernized-app/application/eshop.Dockerfile
+++ b/eshop-mvc-modernized-app/application/eshop.Dockerfile
@@ -21,7 +21,7 @@ RUN powershell New-Item -ItemType Directory C:\LogMonitor; $downloads = @( @{ ur
 
 RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
 
-RUN xcopy c:\build\src\eShopModernizedMVC\* c:\inetpub\wwwroot /s
+RUN xcopy .\application\src\eShopModernizedMVC\* c:\inetpub\wwwroot /s
 
 # Enable ETW logging for Default Web Site on IIS
 RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost


### PR DESCRIPTION
The current structure for the `docker build ` on the eshop app doesn't work.

- The `dockerfile` references a full path that doesn't exist on the machine of someone who cloned the repo.
- The `docker build `command is incorrect.
