### PR TITLE
A workaround for deploying the app on AKS version 1.24.x

### DIFF
--- a/django-poll-app/README.md
+++ b/django-poll-app/README.md
@@ -83,7 +83,7 @@ Initially, we need to create Azure Container Registry(ACR):
 
 Open Powershell, login to Azure using the command *"az login"*.
 
-We have created powershell scripts to create resources on Azure. Before running these script, we need to specify parameter values in [variables.txt](.\scripts\powershell-scripts\variables.txt) file.
+We have created powershell scripts to create resources on Azure. Before running these script, we need to specify parameter values in [variables.txt](scripts/powershell-scripts/variables.txt) file.
 
 ACR is used to store docker image of the application. Follow the below path to get the script:
 
@@ -98,7 +98,7 @@ Run above script using:
 ## Push the custom Docker image to ACR
 
 ```powershell
-az acr login <acr-container-registry>
+az acr login -n <acr-container-registry-name>
 docker tag poll_app:latest <acr-container-registry>.azurecr.io/poll_app:latest
 docker push <acr-container-registry>.azurecr.io/poll_app:latest
 ```

--- a/eshop-mvc-modernized-app/README.md
+++ b/eshop-mvc-modernized-app/README.md
@@ -45,37 +45,36 @@ Figure below shows the containerized eShop legacy web application and deployment
 This is the docker file
 
 ```dockerfile
-FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019  
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
 
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:ChocolateyUseWindowsCompression='false'; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+# Install build tools
+RUN powershell add-windowsfeature web-asp-net45 \
+    && choco install microsoft-build-tools -y --allow-empty-checksums -version 14.0.23107.10 \
+    && choco install dotnet4.6-targetpack --allow-empty-checksums -y \
+    && choco install nuget.commandline --allow-empty-checksums -y \
+    && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
+    && nuget install WebConfigTransformRunner -Version 1.0.0.1
+
+# Install LogMonitor.exe
+RUN powershell New-Item -ItemType Directory C:\LogMonitor; $downloads = @(@{ uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.2/LogMonitor.exe'; outFile = 'C:\LogMonitor\LogMonitor.exe' }, @{ uri = 'https://raw.githubusercontent.com/microsoft/windows-container-tools/main/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json'; outFile = 'C:\LogMonitor\LogMonitorConfig.json' } ); $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
 
 # Copy files
 RUN md c:\build
 WORKDIR c:/build
 COPY . c:/build
 
-# Install build tools
-RUN powershell Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile Nuget.exe
-RUN powershell add-windowsfeature web-asp-net45 \
-    && choco install microsoft-build-tools -y --allow-empty-checksums -version 14.0.23107.10 \
-    && choco install dotnet4.6-targetpack --allow-empty-checksums -y \
-    && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
-    && nuget install WebConfigTransformRunner -Version 1.0.0.1
-
-# Install LogMonitor.exe
-RUN powershell New-Item -ItemType Directory C:\LogMonitor; $downloads = @( @{ uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.1/LogMonitor.exe'; outFile = 'C:\LogMonitor\LogMonitor.exe' }, @{ uri = 'https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json'; outFile = 'C:\LogMonitor\LogMonitorConfig.json' } ); $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
-
 RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
-
 RUN xcopy c:\build\src\eShopModernizedMVC\* c:\inetpub\wwwroot /s
 
 # Enable ETW logging for Default Web Site on IIS
 RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost
 
-# Start "C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc and application"
-
-ENTRYPOINT powershell .\Startup; C:\\LogMonitor\\LogMonitor.exe ; C:\\ServiceMonitor.exe w3svc
+# Start "C:\LogMonitor\LogMonitor.exe and application"
+SHELL ["C:/LogMonitor/LogMonitor.exe", "powershell.exe"]
+ENTRYPOINT ["powershell.exe", "./Startup.ps1"]
 ```
 
 We are using Windows Server Core Image and Installing necessary tools for building our project.
@@ -210,8 +209,8 @@ On Powershell
 $keyVaultName = "<Azure-Key-Vault-Name>"
 $secret1Name = "CatalogDBContext"
 $secret2Name = "StorageConnectionString"
-az keyvault secret set --name $secret1Name --value "DataSource=<database-connection-string> " –-vault-name $keyVaultName
-az keyvault secret set --name $secret2Name --value "DataSource=<storageaccountconnectionstring>" –-vault-name $keyVaultName
+az keyvault secret set --name $secret1Name --value "Data Source=<your sql server host>;User Id=<your sql server username>;Password=<Your SQl server password>;Initial Catalog=<your database name>;" –-vault-name $keyVaultName
+az keyvault secret set --name $secret2Name --value "<storageaccountconnectionstring>" –-vault-name $keyVaultName
 ```
 
 ## Create Azure File Share Secrets

--- a/eshop-mvc-modernized-app/README.md
+++ b/eshop-mvc-modernized-app/README.md
@@ -88,13 +88,13 @@ Also implementing IIS Log Monitor for ASP.NET Windows Containers.
 
 ```powershell
 git clone https://github.com/microsoft/windows-containers-demos  #Working directory is D:/
-cd windows-containers-demos # Current working directory is D: \windows-containers-demos 
+cd windows-containers-demos # Current working directory is D:\windows-containers-demos 
 ```
 
 ## Building Docker Image
 
 ```powershell
-cd D:\windows-containers-demos\eshop-mvc-modernized-app
+cd D:\windows-containers-demos\eshop-mvc-modernized-app\application\
 docker build -t eshopapp:v2.1  -f .\eshop.Dockerfile .
 ```
 

--- a/eshop-mvc-modernized-app/application/Startup.ps1
+++ b/eshop-mvc-modernized-app/application/Startup.ps1
@@ -1,5 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+
+# Update Web.config with Database and storage account connection strings
+.\Set-WebConfigSettings.ps1 -webConfig c:\inetpub\wwwroot\Web.config
+
+# Start ServiceMonitor
+C:\ServiceMonitor.exe w3svc
+
 $ErrorActionPreference = "Stop"
 
 Write-Output "Configuring IIS with authentication."
@@ -16,12 +23,6 @@ Start-IISCommitDelay
 Stop-IISCommitDelay
 
 Write-Output "IIS with authentication is ready."
-
-C:\ServiceMonitor.exe w3svc
-
-.\Set-WebConfigSettings.ps1 -webConfig c:\inetpub\wwwroot\Web.config
-#.\add_certificate_IIS.ps1
-#C:\ServiceMonitor.exe w3svc
 
 If (Test-Path Env:\ASPNET_ENVIRONMENT)
 {

--- a/eshop-mvc-modernized-app/application/eshop.Dockerfile
+++ b/eshop-mvc-modernized-app/application/eshop.Dockerfile
@@ -1,23 +1,23 @@
-FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019  
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
 
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:ChocolateyUseWindowsCompression='false'; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+# Install build tools
+RUN powershell add-windowsfeature web-asp-net45 \
+    && choco install microsoft-build-tools -y --allow-empty-checksums -version 14.0.23107.10 \
+    && choco install dotnet4.6-targetpack --allow-empty-checksums -y \
+    && choco install nuget.commandline --allow-empty-checksums -y \
+    && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
+    && nuget install WebConfigTransformRunner -Version 1.0.0.1
+
+# Install LogMonitor.exe
+RUN powershell New-Item -ItemType Directory C:\LogMonitor; $downloads = @(@{ uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.2/LogMonitor.exe'; outFile = 'C:\LogMonitor\LogMonitor.exe' }, @{ uri = 'https://raw.githubusercontent.com/microsoft/windows-container-tools/main/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json'; outFile = 'C:\LogMonitor\LogMonitorConfig.json' } ); $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
 
 # Copy files
 RUN md c:\build
 WORKDIR c:/build
 COPY . c:/build
-
-# Install build tools
-RUN powershell Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile Nuget.exe
-RUN powershell add-windowsfeature web-asp-net45 \
-    && choco install microsoft-build-tools -y --allow-empty-checksums -version 14.0.23107.10 \
-    && choco install dotnet4.6-targetpack --allow-empty-checksums -y \
-    && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
-    && nuget install WebConfigTransformRunner -Version 1.0.0.1
-	
-# Install LogMonitor.exe
-RUN powershell New-Item -ItemType Directory C:\LogMonitor; $downloads = @( @{ uri = 'https://github.com/microsoft/windows-container-tools/releases/download/v1.1/LogMonitor.exe'; outFile = 'C:\LogMonitor\LogMonitor.exe' }, @{ uri = 'https://raw.githubusercontent.com/microsoft/iis-docker/master/windowsservercore-insider/LogMonitorConfig.json'; outFile = 'C:\LogMonitor\LogMonitorConfig.json' } ); $downloads.ForEach({ Invoke-WebRequest -UseBasicParsing -Uri $psitem.uri -OutFile $psitem.outFile })
 
 RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
 
@@ -26,6 +26,6 @@ RUN xcopy c:\build\src\eShopModernizedMVC\* c:\inetpub\wwwroot /s
 # Enable ETW logging for Default Web Site on IIS
 RUN c:\windows\system32\inetsrv\appcmd.exe set config -section:system.applicationHost/sites /"[name='Default Web Site'].logFile.logTargetW3C:"File,ETW"" /commit:apphost
 
-# Start "C:\LogMonitor\LogMonitor.exe C:\ServiceMonitor.exe w3svc and application"
-
-ENTRYPOINT powershell .\Startup; C:\\LogMonitor\\LogMonitor.exe ; C:\\ServiceMonitor.exe w3svc
+# Start "C:\LogMonitor\LogMonitor.exe and application"
+SHELL ["C:/LogMonitor/LogMonitor.exe", "powershell.exe"]
+ENTRYPOINT ["powershell.exe", "./Startup.ps1"]

--- a/eshop-mvc-modernized-app/application/src/eShopModernizedMVC/Web.config
+++ b/eshop-mvc-modernized-app/application/src/eShopModernizedMVC/Web.config
@@ -23,7 +23,7 @@
   
     <!-- This DB connection string is only used if running the app on plain .NET -->
     <!-- If you are using Windows Containers, then the DB connString being used is at the docker-compose.override.yml file -->
-    <add name="CatalogDBContext" connectionString="Server=Data Source=<server-name>;User Id=<user>;Password=<password>;Initial Catalog=<database-name>" providerName="System.Data.SqlClient" />
+    <add name="CatalogDBContext" connectionString="Data Source=#sql-server-name#;User Id=#sqluser#;Password=#sqluserpassword#;Initial Catalog=#sql-database-name#;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings configBuilders="Secrets,Environment,AzureKeyVault">
      <add key="KeyVaultName" value="" />

--- a/ticket-desk/README.md
+++ b/ticket-desk/README.md
@@ -56,20 +56,21 @@ RUN powershell add-windowsfeature web-asp-net45 \
     && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
     && nuget install WebConfigTransformRunner -Version 1.0.0.1
 
-RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
-
 # Copy files
 RUN md c:\build
 WORKDIR c:/build
 COPY . c:/build
 
+RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
+
 # Restore packages, build, copy
-RUN nuget restore
 RUN powershell Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile c:/build/.nuget/nuget.exe
+RUN nuget restore
 RUN C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe /p:Platform="Any CPU" /p:VisualStudioVersion=12.0 /p:VSToolsPath=c:\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\tools\VSToolsPath TicketDesk2.sln
 RUN xcopy c:\build\TicketDesk.Web.Client\* c:\inetpub\wwwroot /s
 
-ENTRYPOINT powershell .\Startup
+# Start application
+ENTRYPOINT ["powershell.exe", "./Startup.ps1"]
 ```
 
 We are using Windows Server Core Image and installing necessary tools for building our project.
@@ -157,7 +158,7 @@ First create Azure Container Registry.
 
 Open Powershell, login to Azure using command `az login`.
 
-> We have created powershell scripts to deploy resources on Azure. Before running powershell script first we have to provide parameters value in [variables.txt](.\scripts\powershell-scripts\variables.txt) file.
+> We have created powershell scripts to deploy resources on Azure. Before running powershell script first we have to provide parameters value in [variables.txt](scripts/powershell-scripts/variables.txt) file.
 
 The first service we are going to create is Azure Container Registry (ACR). It is used for storing application docker image, so, for creating ACR run following script
 

--- a/ticket-desk/application/ticketDesk.Dockerfile
+++ b/ticket-desk/application/ticketDesk.Dockerfile
@@ -11,17 +11,18 @@ RUN powershell add-windowsfeature web-asp-net45 \
     && nuget install MSBuild.Microsoft.VisualStudio.Web.targets -Version 14.0.0.3 \
     && nuget install WebConfigTransformRunner -Version 1.0.0.1
 
-RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
-
 # Copy files
 RUN md c:\build
 WORKDIR c:/build
 COPY . c:/build
 
+RUN powershell remove-item C:\inetpub\wwwroot\iisstart.*
+
 # Restore packages, build, copy
-RUN nuget restore
 RUN powershell Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile c:/build/.nuget/nuget.exe
+RUN nuget restore
 RUN C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe /p:Platform="Any CPU" /p:VisualStudioVersion=12.0 /p:VSToolsPath=c:\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\tools\VSToolsPath TicketDesk2.sln
 RUN xcopy c:\build\TicketDesk.Web.Client\* c:\inetpub\wwwroot /s
 
-ENTRYPOINT powershell .\Startup
+# Start application
+ENTRYPOINT ["powershell.exe", "./Startup.ps1"]


### PR DESCRIPTION
The image build from current Dockerfile fails to deploy you AKS version 1.24.x.

- This PR contains updated instructions for Dockerfile.
- Updated ReadMe, fixes for Web.config, and PS file in dotNet applications.
